### PR TITLE
Initialize process.tab.category to preempt errors

### DIFF
--- a/R/PDE.R
+++ b/R/PDE.R
@@ -3754,6 +3754,8 @@ PDE_install_Xpdftools4.02 <- function(sysname=NULL, bin=NULL, verbose=TRUE, perm
 
   ## 7.1) Second search of search words in htmllines -----------------------------------------------
 
+  processed.tab.category <- character(0)
+
   if (filterwords.go == TRUE &&
       integrity.indicator == TRUE &&
       nrow(as.data.frame((htmltablelines))) > 0 && ncol(as.data.frame((htmltablelines))) > 0 &&


### PR DESCRIPTION
Hi! I tried this package and it resulted in an error: "processed.tab.category not found", so I looked into the code.

I came up with a hacky solution: just add a line to initialize this object. I'm not sure if it's the best solution but it worked for me. I used `character(0)` but could also be `NULL`. I didn't really had time to weight in which one is better though.

In any case, it works for me. The line is 3757 in PDE.R:

```r
processed.tab.category <- character(0)
```